### PR TITLE
Fix: "Browse Challenges"  button not working fixed

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,8 +12,8 @@ import { Challenge } from './components/Challenges/ChallengeCard';
 import { ThemeProvider } from './themeContent'; // Import the new ThemeProvider
 import ScrollToTop from './components/ScrollToTop/ScrollToTop';
 
-
 function App() {
+   
   const [currentPage, setCurrentPage] = useState<string>('home');
   const [selectedChallenge, setSelectedChallenge] = useState<Challenge | null>(null);
 
@@ -48,7 +48,7 @@ function App() {
       case 'submit':
         return <SubmitChallenge />;
       case 'community':
-        return <Community />;
+        return <Community onNavigate={handleNavigate} />; {/* ✅ updated */}
       default:
         return (
           <>

--- a/src/components/Community/Community.tsx
+++ b/src/components/Community/Community.tsx
@@ -14,6 +14,10 @@ interface Submission {
   isLiked?: boolean;
 }
 
+interface CommunityProps {
+  onNavigate: (page: string) => void;
+}
+
 const mockSubmissions: Submission[] = [
   {
     id: '1',
@@ -61,7 +65,7 @@ const mockSubmissions: Submission[] = [
   }
 ];
 
-export const Community: React.FC = () => {
+export const Community: React.FC<CommunityProps> = ({ onNavigate }) => {
   const [selectedDomain, setSelectedDomain] = useState('All');
   const [searchTerm, setSearchTerm] = useState('');
   const [likedSubmissions, setLikedSubmissions] = useState<Set<string>>(new Set());
@@ -223,7 +227,10 @@ export const Community: React.FC = () => {
           <p className="text-purple-700 dark:text-purple-300 mb-6">
             Complete challenges and get valuable feedback from our supportive community
           </p>
-          <button className="px-6 py-3 bg-purple-600 hover:bg-purple-700 text-white rounded-lg font-medium transition-all hover:transform hover:scale-105">
+          <button
+            onClick={() => onNavigate('challenges')}
+            className="px-6 py-3 bg-purple-600 hover:bg-purple-700 text-white rounded-lg font-medium transition-all hover:transform hover:scale-105"
+          >
             Browse Challenges
           </button>
         </div>


### PR DESCRIPTION
Description

Fixed the Browse Challenges button navigation in both Community sections.
The button previously had no onClick handler and did not navigate.
Now it correctly uses the onNavigate("challenges") function to redirect to the Challenge Board.

Related Issue
Closes #49 (Browse Challenges button not working)

Checklist

 I have tested my changes locally.
 I have updated documentation if needed.
 This PR follows the project’s coding guidelines.
